### PR TITLE
test(shared-tree): add summary size measurement to test report

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/summary.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree/summary.bench.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 
 import { IsoBuffer } from "@fluid-internal/client-utils";
-import { BenchmarkType, benchmark } from "@fluid-tools/benchmark";
+import { BenchmarkType, benchmarkCustom, benchmark } from "@fluid-tools/benchmark";
 import type { IChannelServices } from "@fluidframework/datastore-definitions/internal";
 import type { ITree } from "@fluidframework/driver-definitions/internal";
 import type { ISummaryTree } from "@fluidframework/driver-definitions";
@@ -51,20 +51,37 @@ describe("Summary benchmarks", () => {
 		});
 		for (const [numberOfNodes, minLength, maxLength] of nodesCountWide) {
 			it(`a wide tree with ${numberOfNodes} nodes.`, async () => {
-				const summaryTree = getSummaryTree(makeWideContentWithEndValue(numberOfNodes, 1));
-				const summaryString = JSON.stringify(summaryTree);
-				const summarySize = IsoBuffer.from(summaryString).byteLength;
-				assert(summarySize > minLength);
-				assert(summarySize < maxLength);
+				benchmarkCustom({
+					only: false,
+					type: BenchmarkType.Measurement,
+					title: `a wide tree with ${numberOfNodes} nodes.`,
+					run: async (reporter) => {
+						const summaryTree = getSummaryTree(makeWideContentWithEndValue(numberOfNodes, 1));
+						const summaryString = JSON.stringify(summaryTree);
+						const summarySize = IsoBuffer.from(summaryString).byteLength;
+						reporter.addMeasurement("summarySize", summarySize);
+						assert(summarySize > minLength);
+						assert(summarySize < maxLength);
+					},
+
+				});
 			});
 		}
 		for (const [numberOfNodes, minLength, maxLength] of nodesCountDeep) {
 			it(`a deep tree with ${numberOfNodes} nodes.`, async () => {
-				const summaryTree = getSummaryTree(makeDeepContent(numberOfNodes));
-				const summaryString = JSON.stringify(summaryTree);
-				const summarySize = IsoBuffer.from(summaryString).byteLength;
-				assert(summarySize > minLength);
-				assert(summarySize < maxLength);
+				benchmarkCustom({
+					only: false,
+					type: BenchmarkType.Measurement,
+					title: `a deep tree with ${numberOfNodes} nodes.`,
+					run: async (reporter) => {
+						const summaryTree = getSummaryTree(makeDeepContent(numberOfNodes));
+						const summaryString = JSON.stringify(summaryTree);
+						const summarySize = IsoBuffer.from(summaryString).byteLength;
+						reporter.addMeasurement("summarySize", summarySize);
+						assert(summarySize > minLength);
+						assert(summarySize < maxLength);
+					},
+				});
 			});
 		}
 	});


### PR DESCRIPTION
## Description

Update Shared Tree summary size benchmarks

## Breaking Changes

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.
> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
> If there are no breaking changes, delete this section.

## Sample output
~~~

~~~
