### PR TITLE
Simplify and fix presence in ai-collab example app

### DIFF
--- a/examples/apps/ai-collab/next.config.ts
+++ b/examples/apps/ai-collab/next.config.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { NextConfig } from "next/types";
+
+// We deliberately configure NextJS to not use React Strict Mode, so we don't get double-rendering of React components
+// during development. Otherwise containers get loaded twice, and the presence functionality works incorrectly, detecting
+// every browser tab that *loaded* a container (but not the one that originally created it) as 2 presence participants.
+
+const nextConfig: NextConfig = {
+  reactStrictMode: false,
+}
+
+// eslint-disable-next-line import/no-default-export -- NextJS prefers it this way
+export default nextConfig;

--- a/examples/apps/ai-collab/src/app/page.tsx
+++ b/examples/apps/ai-collab/src/app/page.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { acquirePresenceViaDataObject } from "@fluidframework/presence/alpha";
+import { acquirePresenceViaDataObject, type IPresence } from "@fluidframework/presence/alpha";
 import {
 	Box,
 	Button,
@@ -18,8 +18,6 @@ import {
 } from "@mui/material";
 import type { IFluidContainer, TreeView } from "fluid-framework";
 import React, { useEffect, useState } from "react";
-
-import { buildUserPresence, type UserPresence } from "./presence";
 
 import { TaskGroup } from "@/components/TaskGroup";
 import { UserPresenceGroup } from "@/components/UserPresenceGroup";
@@ -51,7 +49,7 @@ export async function createAndInitializeContainer(): Promise<
 export default function TasksListPage(): JSX.Element {
 	const [selectedTaskGroup, setSelectedTaskGroup] = useState<SharedTreeTaskGroup>();
 	const [treeView, setTreeView] = useState<TreeView<typeof SharedTreeAppState>>();
-	const [userPresenceGroup, setUserPresenceGroup] = useState<UserPresence>();
+	const [presence, setPresence] = useState<IPresence>();
 
 	const { container, isFluidInitialized, data } = useFluidContainerNextJs(
 		containerIdFromUrl(),
@@ -63,9 +61,8 @@ export default function TasksListPage(): JSX.Element {
 			const _treeView = fluidContainer.initialObjects.appState.viewWith(TREE_CONFIGURATION);
 			setTreeView(_treeView);
 
-			const presence = acquirePresenceViaDataObject(fluidContainer.initialObjects.presence);
-			const _userPresenceGroup = buildUserPresence(presence);
-			setUserPresenceGroup(_userPresenceGroup);
+			const _presence = acquirePresenceViaDataObject(fluidContainer.initialObjects.presence);
+			setPresence(_presence);
 
 			return { sharedTree: _treeView };
 		},
@@ -89,7 +86,7 @@ export default function TasksListPage(): JSX.Element {
 			sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
 			maxWidth={false}
 		>
-			{userPresenceGroup && <UserPresenceGroup userPresenceGroup={userPresenceGroup} />}
+			{presence && <UserPresenceGroup presence={presence} />}
 			<Typography variant="h2" sx={{ my: 3 }}>
 				My Work Items
 			</Typography>

--- a/examples/apps/ai-collab/src/app/presence.ts
+++ b/examples/apps/ai-collab/src/app/presence.ts
@@ -5,24 +5,23 @@
 
 import {
 	IPresence,
-	LatestMap,
+	Latest,
 	type PresenceStates,
 	type PresenceStatesSchema,
 } from "@fluidframework/presence/alpha";
-import { v4 as uuid } from "uuid";
 
 export interface User {
 	photo: string;
 }
 
 const statesSchema = {
-	onlineUsers: LatestMap<{ value: User }, `id-${string}`>(),
+	onlineUsers: Latest<User>({ photo: "" }),
 } satisfies PresenceStatesSchema;
 
 export type UserPresence = PresenceStates<typeof statesSchema>;
 
 // Takes a presence object and returns the user presence object that contains the shared object states
 export function buildUserPresence(presence: IPresence): UserPresence {
-	const states = presence.getStates(`name:user-avatar-states-${uuid()}`, statesSchema);
+	const states = presence.getStates(`name:user-avatar-states`, statesSchema);
 	return states;
 }


### PR DESCRIPTION
This seems to fix the issues with presence we're having. A few callouts:

- Simplified from a LatestMapValueManager to a LatestValueManager, since we just have 1 value to keep track of per participant (the photoUrl).
- Removed used of uuids in favor of `sessionId` provided by the presence package.
- Moved a couple of things around to appease React's linting rules.
- Needed to configure NextJS to not use React strict mode so components aren't rendered twice. Otherwise, when loading a container it is loaded twice and it shows up as 2 presence participants.
